### PR TITLE
ded/ci 11

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -20,6 +20,7 @@ jobs:
         with:
           node-version: '20'
           registry-url: 'https://registry.npmjs.org'
+          scope: '@durolabs'
 
       - name: Install dependencies
         run: npm ci


### PR DESCRIPTION
- **use npm registry**
- **revert back to `NATS_JS_ACCESS_TOKEN`**
- **set token and publish**
- **lets try npm_token**
- **adds @durolabs scope**
